### PR TITLE
Handle `optional` field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-
 members = [
 	"derive",
 	"example",

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -79,6 +79,7 @@ pub enum ProtobufType {
     Double,
 }
 
+#[derive(Clone, Copy)]
 pub enum FieldModifier {
     None,
     Repeated,

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -11,5 +11,5 @@ prost = "0.11"
 prost-serde-derive = { path = "../derive" }
 
 [build-dependencies]
-prost-build = { git = "https://github.com/tokio-rs/prost" }
+prost-build = "0.11"
 tonic-build = { git = "https://github.com/segfault87/tonic", branch = "create-enum-from-str-name" }


### PR DESCRIPTION
Now, the field like `optional string` or `optional Enum` is handled as default value if it is null or not existed.
Fixed it. But, I left some unimplemented as `todo!()`(Will fix on this PR after conversation)