### PR TITLE
fix: support if oneof has bytes

### DIFF
--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -101,13 +101,13 @@ impl DeriveMeta {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum ProstBytesType {
     Bytes,
     Vec,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ProtobufType {
     Message,
     Enumeration(Path),
@@ -168,6 +168,7 @@ impl TryFrom<&Meta> for ProtobufType {
                     "uint64" => Ok(ProtobufType::Uint64),
                     "float" => Ok(ProtobufType::Float),
                     "double" => Ok(ProtobufType::Double),
+                    "bytes" => Ok(ProtobufType::Bytes(ProstBytesType::Vec)),
                     _ => Err(into_syn_error(ident, "unrecognized type")),
                 }
             }
@@ -269,7 +270,7 @@ impl ProstAttr {
         let mut modifier = None;
         let mut tag = None;
 
-        for meta in meta_args {
+        for meta in meta_args.clone() {
             if let Ok(t) = ProtobufType::try_from(&meta) {
                 set_option_or_err(&mut ty, meta, t)?;
             } else if let Ok(m) = FieldModifier::try_from(&meta) {

--- a/derive/src/deserialize/field.rs
+++ b/derive/src/deserialize/field.rs
@@ -37,7 +37,7 @@ impl<'a> FieldVisitorTokenGenerator<'a> {
 
     fn get_none_value_getter_expr(&self, prost_attr: &ProstAttr) -> Result<TokenStream, ()> {
         let serde = self.serde;
-        let defaut_value = prost_attr.get_default_value();
+        let default_value = prost_attr.get_default_value();
 
         match prost_attr.ty {
             ProtobufType::Enumeration(ref path) => Ok(self.value_getter(
@@ -48,7 +48,7 @@ impl<'a> FieldVisitorTokenGenerator<'a> {
                         None => return Err(#serde::de::Error::unknown_variant(&value, &[])),
                     })
                 },
-                defaut_value,
+                default_value,
             )),
             ProtobufType::Bytes(_) => Ok(self.value_getter(
                 Some(quote! { String }),
@@ -61,7 +61,7 @@ impl<'a> FieldVisitorTokenGenerator<'a> {
                         }
                     })
                 },
-                defaut_value,
+                default_value,
             )),
             ProtobufType::OneOf(_) => {
                 let serde = self.serde;
@@ -86,13 +86,13 @@ impl<'a> FieldVisitorTokenGenerator<'a> {
                             )?
                         )
                     },
-                    defaut_value,
+                    default_value,
                 ))
             },
             _ => Ok(self.value_getter(
                 None,
                 quote! { Some(value) },
-                defaut_value,
+                default_value,
             )),
         }
     }

--- a/tests/proto/oneof.proto
+++ b/tests/proto/oneof.proto
@@ -7,6 +7,7 @@ message Oneof {
         Cat cat = 1;
         Dog dog = 2;
         Wolf wolf = 3;
+        bytes alien = 11;
     }
     optional bool is_wild = 4;
     optional int32 age = 5;

--- a/tests/src/util.rs
+++ b/tests/src/util.rs
@@ -70,10 +70,10 @@ macro_rules! serde_test {
                 $json
             );
 
-            let mesage = $value;
+            let message = $value;
             assert_eq!(
-                tests::util::round_trip_from_message(mesage.clone(), false),
-                mesage
+                tests::util::round_trip_from_message(message.clone(), false),
+                message
             );
         }
 
@@ -84,10 +84,10 @@ macro_rules! serde_test {
                 tests::util::drop_null($json)
             );
 
-            let mesage = $value;
+            let message = $value;
             assert_eq!(
-                tests::util::round_trip_from_message(mesage.clone(), true),
-                mesage
+                tests::util::round_trip_from_message(message.clone(), true),
+                message
             );
         }
     };


### PR DESCRIPTION
https://github.com/tokio-rs/prost/blob/master/prost-derive/src/field/scalar.rs#L445 oneof의 경우엔 `bytes = "vec"`의 형태가 아니라, `bytes`로만 들어가있는 것을 확인했습니다.